### PR TITLE
ssl verify bool/string validation and converting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,9 @@
+# Change Log
+
+## V0.1.1
+
+Add validation around the `defaults:ssl:verify` config entry, allowing for a string value set converting to boolean if needed
+
+## V0.1.0
+
+Pack creation and base actions

--- a/actions/lib/aci.py
+++ b/actions/lib/aci.py
@@ -163,7 +163,6 @@ class ACIBaseActions(Action):
 
         try:
             ssl_check = self.config['defaults']['ssl']['verify']
-            #if isinstance(ssl_check, basestring):
             if type(ssl_check) in (str, unicode):
                 if ssl_check.upper() == "FALSE":
                     ssl_verify = False

--- a/actions/lib/aci.py
+++ b/actions/lib/aci.py
@@ -170,7 +170,7 @@ class ACIBaseActions(Action):
                 ssl_verify = ssl_check
             else:
                 ssl_verify = True
-        except:
+        except Exception:
             ssl_verify = True
 
         try:

--- a/actions/lib/aci.py
+++ b/actions/lib/aci.py
@@ -162,8 +162,16 @@ class ACIBaseActions(Action):
                    'Content-type': 'application/json'}
 
         try:
-            ssl_verify = self.config['defaults']['ssl']['verify']
-        except ValueError:
+            ssl_check = self.config['defaults']['ssl']['verify']
+            #if isinstance(ssl_check, basestring):
+            if type(ssl_check) in (str, unicode):
+                if ssl_check.upper() == "FALSE":
+                    ssl_verify = False
+            elif isinstance(ssl_check, bool):
+                ssl_verify = ssl_check
+            else:
+                ssl_verify = True
+        except:
             ssl_verify = True
 
         try:

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,7 +1,7 @@
 ref: cisco_aci
 name: Cisco ACI
 description: Cisco ACI pack
-version: 0.1.0
+version: 0.1.1
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com
 keywords:


### PR DESCRIPTION
Adds validation in for an string based ssl:verify config file entry.
This is due to my inhouse st2 instance being managed via Saltstack which is writing the line as string.