### PR TITLE
ssl_verify default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## V0.1.2
+
+Missed a validation path and that results in ssl_verify being unset. Added default of `ssl_verify = True`
+
 ## V0.1.1
 
 Add validation around the `defaults:ssl:verify` config entry, allowing for a string value set converting to boolean if needed

--- a/actions/lib/aci.py
+++ b/actions/lib/aci.py
@@ -158,6 +158,7 @@ class ACIBaseActions(Action):
 
     def aci_post(self, endpoint, payload):
         url = 'https://%s/api/%s' % (self.apic_address, endpoint)
+        ssl_verify = True
         headers = {'Accept': 'application/json',
                    'Content-type': 'application/json'}
 


### PR DESCRIPTION
had left an avenue in the validation that resulted in this not being set at all.
fixed that by adding a default = True