### PR TITLE
Conformity of name and ref

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## V0.1.3
+
+Update to pack name to match reference
+
 ## V0.1.2
 
 Missed a validation path and that results in ssl_verify being unset. Added default of `ssl_verify = True`

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,7 +1,7 @@
 ref: cisco_aci
-name: Cisco ACI
+name: cisco_aci
 description: Cisco ACI pack
-version: 0.1.1
+version: 0.1.3
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com
 keywords:


### PR DESCRIPTION
Bring name and reference in conformance within the pack.yaml file.
This is to aid automation of pack installation for inhouse systems.