### PR TITLE
Feb 2021 CI Updates: Mistral->Orquesta & Drop py2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,11 +75,8 @@ jobs:
             sudo apt-get update
             sudo apt -y install gmic optipng
       - run:
-          # NOTE: We try to retry the script up to 5 times if it fails. The command could fail due
-          # to the race (e.g. we try to push changes to index, but index has been updated by some
-          # other pack in the mean time)
           name: Update exchange.stackstorm.org
-          command: ~/ci/.circle/retry_on_failure.sh ~/ci/.circle/deployment
+          command: ~/ci/.circle/deployment
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,8 +76,11 @@ jobs:
             sudo apt -y install gmic optipng
             ~/ci/.circle/install_gh
       - run:
+          # NOTE: We try to retry the script up to 5 times if it fails. The command could fail due
+          # to the race (e.g. we try to push changes to index, but index has been updated by some
+          # other pack in the mean time)
           name: Update exchange.stackstorm.org
-          command: ~/ci/.circle/deployment
+          command: ~/ci/.circle/retry_on_failure.sh ~/ci/.circle/deployment
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,51 +1,6 @@
 version: 2
 
 jobs:
-  build_and_test_python27:
-    docker:
-      - image: circleci/python:2.7
-      - image: rabbitmq:3
-      - image: mongo:3.4
-
-    working_directory: ~/repo
-
-    environment:
-      VIRTUALENV_DIR: "~/virtualenv"
-      # Don't install various StackStorm dependencies which are already
-      # installed by CI again in the various check scripts
-      ST2_INSTALL_DEPS: "0"
-
-    steps:
-      - checkout
-      - restore_cache:
-          key: v1-dependency-cache-py27-{{ checksum "requirements.txt" }}
-      - run:
-          name: Download dependencies
-          command: |
-            git clone -b master git://github.com/stackstorm-exchange/ci.git ~/ci
-            ~/ci/.circle/dependencies
-      - run:
-          name: Run tests (Python 2.7)
-          command: ~/ci/.circle/test
-      - save_cache:
-          key: v1-dependency-cache-py27-{{ checksum "requirements.txt" }}
-          paths:
-            - ~/.cache/pip
-            - ~/.apt-cache
-      # NOTE: We use virtualenv files from Python 2.7 step in "deploy" job so we
-      # only persist paths from this job
-      - persist_to_workspace:
-          root: /
-          paths:
-            - home/circleci/ci
-            - home/circleci/virtualenv
-            - tmp/st2
-            - home/circleci/repo
-            - home/circleci/.gitconfig
-
-  # NOTE: Until we add "python_version" metadata attribute to pack.yaml and
-  # explicitly call which packs work with Python 3.x, Python 3.x failures are
-  # not considered fatal
   build_and_test_python36:
     docker:
       - image: circleci/python:3.6
@@ -87,10 +42,21 @@ jobs:
           paths:
             - ~/.cache/pip
             - ~/.apt-cache
+      # NOTE: We use virtualenv files from Python 3.6 step in "deploy" job so we
+      # only persist paths from this job
+      - persist_to_workspace:
+          root: /
+          paths:
+            - home/circleci/ci
+            - home/circleci/virtualenv
+            - tmp/st2
+            - home/circleci/repo
+            - home/circleci/.gitconfig
+
 
   deploy:
     docker:
-      - image: circleci/python:2.7
+      - image: circleci/python:3.6
 
     working_directory: ~/repo
 
@@ -100,7 +66,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1-dependency-cache-py27-{{ checksum "requirements.txt" }}
+          key: v1-dependency-cache-py36-{{ checksum "requirements.txt" }}
       - attach_workspace:
           at: /
       - run:
@@ -109,26 +75,26 @@ jobs:
             sudo apt-get update
             sudo apt -y install gmic optipng
       - run:
+          # NOTE: We try to retry the script up to 5 times if it fails. The command could fail due
+          # to the race (e.g. we try to push changes to index, but index has been updated by some
+          # other pack in the mean time)
           name: Update exchange.stackstorm.org
-          command:  ~/ci/.circle/deployment
+          command: ~/ci/.circle/retry_on_failure.sh ~/ci/.circle/deployment
 
 workflows:
   version: 2
   # Workflow which runs on each push
   build_test_deploy_on_push:
     jobs:
-      - build_and_test_python27
       - build_and_test_python36
       - deploy:
           requires:
-            - build_and_test_python27
             - build_and_test_python36
           filters:
             branches:
               only: master
   build_test_weekly:
     jobs:
-      - build_and_test_python27
       - build_and_test_python36
     # Workflow which runs nightly - note we don't perform deploy job on nightly
     # build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,7 @@ jobs:
           command: |
             sudo apt-get update
             sudo apt -y install gmic optipng
+            ~/ci/.circle/install_gh
       - run:
           name: Update exchange.stackstorm.org
           command: ~/ci/.circle/deployment

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 ## v1.0.0
 
 * Drop Python 2.7 support
+* Convert workflows to mistral using orquestaconvert
 
 ## v0.2.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
 # Change Log
+## v1.0.0
+
+* Drop Python 2.7 support
+
 ## v0.2.0
 
 - Add find_mac and find_ip actions, aliases, and tests

--- a/actions/setup_epg.yaml
+++ b/actions/setup_epg.yaml
@@ -1,26 +1,26 @@
 ---
-description: "Setup an EPG, link domains and create Static Bindings"
+description: Setup an EPG, link domains and create Static Bindings
 enabled: true
-entry_point: 'workflows/setup_epg.yaml'
-name: "setup_epg"
-pack: "cisco_aci"
+entry_point: workflows/setup_epg.yaml
+name: setup_epg
+pack: cisco_aci
 
-runner_type: "mistral-v2"
+runner_type: orquesta
 
 parameters:
   apic:
-    type: "string"
-    description: "configuration name for APIC to connect to"
+    type: string
+    description: configuration name for APIC to connect to
     position: 0
     required: true
   epg_spec:
-    type: "object"
-    description: "Json Object showing epg structure"
+    type: object
+    description: Json Object showing epg structure
     position: 1
     required: true
   credentials:
-    type: "object"
-    description: "Field to provide username and password, eg { \"user\":\"username\", \"passwd\": \"secret\" }"
+    type: object
+    description: 'Field to provide username and password, eg { "user":"username", "passwd": "secret" }'
     required: false
     secret: true
     position: 2

--- a/actions/workflows/setup_epg.yaml
+++ b/actions/workflows/setup_epg.yaml
@@ -1,78 +1,94 @@
 ---
-version: '2.0'
-
-cisco_aci.setup_epg:
-  description: "Create an EPG with supporting bridge domain and Static Bindings"
-  input:
-    - apic
-    - epg_spec
-    - credentials
-  tasks:
-    build_ap:
-      action: cisco_aci.create_ap
-      input:
-        apic: <% $.apic %>
-        data: <% $.epg_spec %>
-        credentials: <% $.credentials %>
-      on-success:
-        - wait_for_build_ap
-    wait_for_build_ap:
-      action: core.pause
-      input:
-        max_pause: 2
-      on-success:
-        - build_bd 
-    build_bd:
-      action: cisco_aci.create_bd
-      input:
-        apic: <% $.apic %>
-        data: <% $.epg_spec %>
-        credentials: <% $.credentials %>
-      on-success:
-        - wait_for_build_bd
-    wait_for_build_bd:
-      action: core.pause
-      input:
-        max_pause: 2
-      on-success:
-        - build_epg 
-    build_epg:
-      action: cisco_aci.create_epg
-      input:
-        apic: <% $.apic %>
-        data: <% $.epg_spec %>
-        credentials: <% $.credentials %>
-      on-success:
-        - wait_for_build_epg
-    wait_for_build_epg:
-      action: core.pause
-      input:
-        max_pause: 2
-      on-success:
-        - link_domains
-    link_domains:
-      action: cisco_aci.link_domain
-      input:
-        apic: <% $.apic %>
-        data: <% $.epg_spec %>
-        credentials: <% $.credentials %>
-      on-success:
-        - wait_for_link_domains
-    wait_for_link_domains:
-      action: core.pause
-      input:
-        max_pause: 2
-      on-success:
-        - build_static_bindings
-    build_static_bindings:
-      action: cisco_aci.create_static_binding
-      input:
-        apic: <% $.apic %>
-        data: <% $.epg_spec %>
-        credentials: <% $.credentials %>
-      on-success:
-        - wait_for_build_static_bindings
-    wait_for_build_static_bindings:
-      action: core.pause
-      input:
-        max_pause: 2
+version: '1.0'
+description: Create an EPG with supporting bridge domain and Static Bindings
+input:
+  - apic
+  - epg_spec
+  - credentials
+tasks:
+  build_ap:
+    action: cisco_aci.create_ap
+    input:
+      apic: <% ctx().apic %>
+      data: <% ctx().epg_spec %>
+      credentials: <% ctx().credentials %>
+    next:
+      - when: '{{ succeeded() }}'
+        do:
+          - wait_for_build_ap
+  wait_for_build_ap:
+    action: core.pause
+    input:
+      max_pause: 2
+    next:
+      - when: '{{ succeeded() }}'
+        do:
+          - build_bd
+  build_bd:
+    action: cisco_aci.create_bd
+    input:
+      apic: <% ctx().apic %>
+      data: <% ctx().epg_spec %>
+      credentials: <% ctx().credentials %>
+    next:
+      - when: '{{ succeeded() }}'
+        do:
+          - wait_for_build_bd
+  wait_for_build_bd:
+    action: core.pause
+    input:
+      max_pause: 2
+    next:
+      - when: '{{ succeeded() }}'
+        do:
+          - build_epg
+  build_epg:
+    action: cisco_aci.create_epg
+    input:
+      apic: <% ctx().apic %>
+      data: <% ctx().epg_spec %>
+      credentials: <% ctx().credentials %>
+    next:
+      - when: '{{ succeeded() }}'
+        do:
+          - wait_for_build_epg
+  wait_for_build_epg:
+    action: core.pause
+    input:
+      max_pause: 2
+    next:
+      - when: '{{ succeeded() }}'
+        do:
+          - link_domains
+  link_domains:
+    action: cisco_aci.link_domain
+    input:
+      apic: <% ctx().apic %>
+      data: <% ctx().epg_spec %>
+      credentials: <% ctx().credentials %>
+    next:
+      - when: '{{ succeeded() }}'
+        do:
+          - wait_for_link_domains
+  wait_for_link_domains:
+    action: core.pause
+    input:
+      max_pause: 2
+    next:
+      - when: '{{ succeeded() }}'
+        do:
+          - build_static_bindings
+  build_static_bindings:
+    action: cisco_aci.create_static_binding
+    input:
+      apic: <% ctx().apic %>
+      data: <% ctx().epg_spec %>
+      credentials: <% ctx().credentials %>
+    next:
+      - when: '{{ succeeded() }}'
+        do:
+          - wait_for_build_static_bindings
+  wait_for_build_static_bindings:
+    action: core.pause
+    input:
+      max_pause: 2

--- a/actions/workflows/setup_epg.yaml
+++ b/actions/workflows/setup_epg.yaml
@@ -10,44 +10,69 @@ cisco_aci.setup_epg:
   tasks:
     build_ap:
       action: cisco_aci.create_ap
-      wait-after: 2
       input:
         apic: <% $.apic %>
         data: <% $.epg_spec %>
         credentials: <% $.credentials %>
+      on-success:
+        - wait_for_build_ap
+    wait_for_build_ap:
+      action: core.pause
+      input:
+        max_pause: 2
       on-success:
         - build_bd 
     build_bd:
       action: cisco_aci.create_bd
-      wait-after: 2
       input:
         apic: <% $.apic %>
         data: <% $.epg_spec %>
         credentials: <% $.credentials %>
+      on-success:
+        - wait_for_build_bd
+    wait_for_build_bd:
+      action: core.pause
+      input:
+        max_pause: 2
       on-success:
         - build_epg 
     build_epg:
       action: cisco_aci.create_epg
-      wait-after: 2
       input:
         apic: <% $.apic %>
         data: <% $.epg_spec %>
         credentials: <% $.credentials %>
+      on-success:
+        - wait_for_build_epg
+    wait_for_build_epg:
+      action: core.pause
+      input:
+        max_pause: 2
       on-success:
         - link_domains
     link_domains:
       action: cisco_aci.link_domain
-      wait-after: 2
       input:
         apic: <% $.apic %>
         data: <% $.epg_spec %>
         credentials: <% $.credentials %>
       on-success:
+        - wait_for_link_domains
+    wait_for_link_domains:
+      action: core.pause
+      input:
+        max_pause: 2
+      on-success:
         - build_static_bindings
     build_static_bindings:
       action: cisco_aci.create_static_binding
-      wait-after: 2
       input:
         apic: <% $.apic %>
         data: <% $.epg_spec %>
         credentials: <% $.credentials %>
+      on-success:
+        - wait_for_build_static_bindings
+    wait_for_build_static_bindings:
+      action: core.pause
+      input:
+        max_pause: 2

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,7 +1,7 @@
 ref: cisco_aci
 name: cisco_aci
 description: Cisco ACI pack
-version: 0.2.0
+version: 1.0.0
 author: Paul Mulvihill
 email: paul.mulvihill@pulsant.com
 contributors:
@@ -12,5 +12,4 @@ keywords:
   - aci
   - networking
 python_versions:
-  - "2"
   - "3"


### PR DESCRIPTION
- Test infra for py2.7 is broken. Drop it.
- drop py2 support
- drop the deploy retry script
- prepare workflow for orquestaconvert
- Convert workflow from mistral to orquesta
